### PR TITLE
use custom vesion of code-scanning-rubocop

### DIFF
--- a/.github/workflows/rubocop-analysis.yml
+++ b/.github/workflows/rubocop-analysis.yml
@@ -20,10 +20,6 @@ jobs:
       with:
         ruby-version: 2.7
 
-    # This step is not necessary if you add the gem to your Gemfile
-    - name: Install Code Scanning integration
-      run: bundle add code-scanning-rubocop --version 0.3.0 --skip-install
-
     - name: Install dependencies
       run: bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in nanoci.gemspec
 gemspec
+
+gem 'code-scanning-rubocop', github: 'the-vk/code-scanning-rubocop', branch: 'feature-rubocop-1.x'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/the-vk/code-scanning-rubocop
+  revision: c6e9aac6f2666112b1adb935b015025f50fa719f
+  branch: feature-rubocop-1.x
+  specs:
+    code-scanning-rubocop (0.4.0)
+      rubocop (~> 1.0)
+
 PATH
   remote: .
   specs:
@@ -16,8 +24,6 @@ GEM
   specs:
     ast (2.4.1)
     bson (4.11.1)
-    code-scanning-rubocop (0.4.0)
-      rubocop (> 0.82.0)
     concurrent-ruby (1.1.7)
     concurrent-ruby-edge (0.6.0)
       concurrent-ruby (~> 1.1.6)
@@ -94,7 +100,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  code-scanning-rubocop (~> 0.4)
+  code-scanning-rubocop!
   grpc-tools (= 1.16.0)
   nanoci!
   rake (~> 13.0)

--- a/nanoci.gemspec
+++ b/nanoci.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mongo', '~> 2.5'
   spec.add_runtime_dependency 'ruby-enum', '~> 0.7'
 
-  spec.add_development_dependency 'code-scanning-rubocop', '~> 0.4'
+  # spec.add_development_dependency 'code-scanning-rubocop', '~> 0.4'
   spec.add_development_dependency 'grpc-tools', '1.16.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
this change fixes incompatibility of sarif plugin with rubocop 1.x